### PR TITLE
connect to redis container from python container with this

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
       - "8002:8002"
     volumes:
       - ${DATAPATH}:/data/valhalla
+    environment:
+      - REDIS_HOST=redis
 
 networks:
   opentraffic:


### PR DESCRIPTION
@heffergm pointed me to some [docs](https://docs.docker.com/compose/networking/) when asking about how to make two containers talk to each other. after reading it and confirming with @heffergm seems like the python container needs to pass to redis connection api the hostname of the redis container. we supply this via an environment variable to python so one can get at it via something like:

```python
import os
os.environ['REDIS_HOST']
```

@kdiluca 