### PR TITLE
allow the reporter to work on a probes traces one point at a time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,8 @@ services:
       - DATASTORE_URL=http://172.17.0.1:8003/store?
       - STALE_TIME=60
       - PARTIAL_EXPIRY=300
-      - MAX_TRACE_SIZE=120
-      - MAX_TIME_DIFF=120
+      - MIN_TRACE_DIST=1000
+      - MIN_ELAPSED_TIME=120
 
 networks:
   opentraffic:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - DATASTORE_URL=http://172.17.0.1:8003/store?
       - STALE_TIME=60
       - PARTIAL_EXPIRY=300
+      - MAX_TRACE_SIZE=120
+      - MAX_TIME_DIFF=120
 
 networks:
   opentraffic:

--- a/py/make_requests.sh
+++ b/py/make_requests.sh
@@ -46,7 +46,7 @@ for file in ${files}; do
   #download in the foreground
   echo "Retrieving ${file} from s3" && aws s3 cp ${s3_dir}${file} . &> /dev/null
   #make requests with just this file
-  zcat ${file} | sort | ./to_post_body.py --time-between 0 --batch-size 1 - | parallel --no-notice -j ${par} wget ${url} -O - -q --post-data '{}'\; echo ""
+  zcat ${file} | sort | ./to_post_body.py - | parallel --no-notice -j ${par} wget ${url} -O - -q --post-data '{}'\; echo ""
   #done with this
   echo "Finished POST'ing ${file}" && rm -f ${file}
 done

--- a/py/make_requests.sh
+++ b/py/make_requests.sh
@@ -9,15 +9,14 @@ fi
 set -e
 
 function usage {
-  echo -e "Usage:\n-s s3 bucket url\n-f regex to use with grep to get interesting files\n-u reporter url\n-j concurrency for posting requests\n-b whether to run in the downloads in the background or not\n" 1>&2
-  echo "Example: AWS_DEFAULT_PROFILE=big_data $0 -s s3://heaps_of_data/2016_11/ -f 2016_11_01.*gz -u http://opentraffic.io/report? -j 16 -b" 1>&2
+  echo -e "Usage:\n-s s3 bucket url\n-f regex to use with grep to get interesting files\n-u reporter url\n-j concurrency for posting requests\n" 1>&2
+  echo "Example: AWS_DEFAULT_PROFILE=big_data $0 -s s3://heaps_of_data/2016_11/ -f 2016_11_01.*gz -u http://opentraffic.io/report? -j 16" 1>&2
   echo "Note: bucket listing is not recursive" 1>&2
   echo "Note: data is pipe delimited: date|id|x|x|x|x|x|x|x|lat|lon|x|x with date format: %Y-%m-%d %H:%M:%S" 1>&2
   exit 1
 }
 
 par=$(nproc)
-unset bgrnd
 while getopts ":s:f:u:j:b" opt; do
   case $opt in
     s) s3_dir=$(echo ${OPTARG} | sed -e 's@/\?$@/@g')
@@ -27,8 +26,6 @@ while getopts ":s:f:u:j:b" opt; do
     u) url="${OPTARG}"
     ;;
     j) par="${OPTARG}"
-    ;;
-    b) bgrnd="${OPTARG}"
     ;;
     \?) echo "Invalid option -${OPTARG}" 1>&2 && usage
     ;;
@@ -45,27 +42,13 @@ files=$(aws s3 ls ${s3_dir} | awk '{print $4}' | grep -E ${file_re} | tr '\n' ' 
 echo "Processing $(echo ${files} | tr ' ' '\n' | wc -l) files"
 
 
-if [[ ! -z ${bgrnd+x} ]]; then
-  echo "Continuously POST'ing..."
-  #start downloading them in the background
-  (
-    for file in ${files}; do
-      echo "Retrieving ${file} from s3"
-      aws s3 cp ${s3_dir}${file} . &> /dev/null
-      echo "Retrieved ${file} from s3"
-    done
-  ) &
-  #start making requests in the foreground
-  ./wait_cat.py --delete ${files} | zcat - | ./to_post_body.py - | parallel --no-notice -j ${par} wget ${url} -O - -q --post-data '{}'\; echo ""
-else
-  for file in ${files}; do
-    #download in the foreground
-    echo "Retrieving ${file} from s3" && aws s3 cp ${s3_dir}${file} . &> /dev/null
-    #make requests with just this file
-    zcat ${file} | ./to_post_body.py - | parallel --no-notice -j ${par} wget ${url} -O - -q --post-data '{}'\; echo ""
-    #done with this
-    echo "Finished POST'ing ${file}" && rm -f ${file}
-  done
-fi
+for file in ${files}; do
+  #download in the foreground
+  echo "Retrieving ${file} from s3" && aws s3 cp ${s3_dir}${file} . &> /dev/null
+  #make requests with just this file
+  zcat ${file} | sort | ./to_post_body.py --time-between 0 --batch-size 1 - | parallel --no-notice -j ${par} wget ${url} -O - -q --post-data '{}'\; echo ""
+  #done with this
+  echo "Finished POST'ing ${file}" && rm -f ${file}
+done
 
 

--- a/py/to_post_body.py
+++ b/py/to_post_body.py
@@ -17,8 +17,6 @@ args.file = args.file[0]
 
 #output a single body
 def emit(trace):
-  if len(trace['trace']) < 2:
-    return
   if args.output_format == 'json':
     sys.stdout.write(json.dumps(trace, separators=(',', ':')) + os.linesep)
   else:
@@ -43,7 +41,7 @@ for line in handle:
       uuids[uuid] = {'uuid': uuid, 'trace':[]}
     trace = uuids[uuid]['trace']
     #if its been too much time or we hit the batch size
-    if (len(trace) and reading['time'] - trace[-1]['time'] > args.time_between) or len(trace) > args.batch_size:
+    if (len(trace) and reading['time'] - trace[-1]['time'] > args.time_between) or len(trace) >= args.batch_size:
       emit(uuids[uuid])
       uuids[uuid] = {'uuid': uuid, 'trace':[reading]}
     #append
@@ -56,7 +54,8 @@ for line in handle:
     uuids = {}
 #flush anything left
 for k,v in uuids.iteritems():
-  emit(v)
+  if len(v['trace']):
+    emit(v)
 #done
 if args.file != '-':
   handle.close()


### PR DESCRIPTION
this removes the requirement that requests have to be more than one point. this should allow for a streaming architecture such as kafka to sit in front of the reporter and pump in single points. this puts considerably more burden on redis as it has to keep in memory possibly a bunch more trace data.

the running characteristics of this change seemed ok at first but there is a considerable issue that i think we should tackle before merging this. ill note it in the diff