### PR TITLE
Reporter Stats

### DIFF
--- a/py/reporter_service.py
+++ b/py/reporter_service.py
@@ -174,7 +174,7 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
           if (speed < 200):
             datastore_out['reports'].append(report)
             successful_count += 1
-            successful_length = (prior_length * 0.001) #convert meters to km
+            successful_length = round((prior_length * 0.001),3) #convert meters to km
           else:
             #Log this as an error
             sys.stderr.write("Speed exceeds 200kph\n")
@@ -182,7 +182,7 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
         #Log prior segments on local level not being reported; lets do a count and track prior_segment_ids
         else:
           unreported_count += 1
-          unreported_length = (prior_length * 0.001) #convert meters to km
+          unreported_length = round((prior_length * 0.001),3) #convert meters to km
       #log if prior segment is incomplete
       else:
         incomplete_seg_count += 1

--- a/py/reporter_service.py
+++ b/py/reporter_service.py
@@ -158,9 +158,8 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
       #check if segment Id is on the local level
       level = (segment_id & 0x7) if segment_id != None else -1
 
-      #Output if both this segment and prior segment are complete
-      if (segment_id != None and length > 0 and prior_segment_id != None and prior_length > 0):
-        #Conditonally output prior segments on local level
+      #Conditionally output prior segment if it is complete and the level is configured to be reported
+      if prior_segment_id != None and prior_length > 0:
         if prior_level in thread_local.report_levels:
           #Add the prior segment. Next segment is set to empty if transition onto local level
           report = {}
@@ -184,6 +183,7 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
         else:
           unreported_count += 1
           unreported_length = (prior_length * 0.001) #convert meters to km
+
       #Save state for next segment.
       if internal == True and first_seg != True:
         #Do not replace information on prior segment, except to mark the prior as internal

--- a/py/reporter_service.py
+++ b/py/reporter_service.py
@@ -157,7 +157,7 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
 
       #check if segment Id is on the local level
       level = (segment_id & 0x7) if segment_id != None else -1
-      
+
       #Output if both this segment and prior segment are complete
       if (segment_id != None and length > 0 and prior_segment_id != None and prior_length > 0):
         #Conditonally output prior segments on local level
@@ -196,7 +196,7 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
         prior_length = length
         prior_level = level
         prior_queue_length = queue_length
-        
+
       first_seg = False
       idx += 1
       #Track segments that match to edges that do not have any OSMLR Id but are not internal (turn channel, roundabout, internal intersection) -
@@ -219,13 +219,12 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
     
     if not datastore_out['reports']:
       datastore_out.pop('reports')
-      
+
     if shape_used:
       data['shape_used'] = shape_used
     data['segment_matcher'] = segments
     data['datastore'] = datastore_out
     data['stats'] = stats
-
     return json.dumps(data, separators=(',', ':'))
 
   #parse the request because we dont get this for free!

--- a/py/reporter_service.py
+++ b/py/reporter_service.py
@@ -180,7 +180,7 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
             #Log this as an error
             sys.stderr.write("Speed exceeds 200kph\n")
             invalid_speed_count += 1
-        #Log prior segments on local level not being reported; lets do a count and track prior_segment_ids & way_ids 
+        #Log prior segments on local level not being reported; lets do a count and track prior_segment_ids
         else:
           unreported_count += 1
           unreported_length = (prior_length * 0.001) #convert meters to km
@@ -204,27 +204,23 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
       if segment_id is None and internal == False:
         unassociated_seg_count += 1
 
-    successful, unreported, match_errors, stats, data = [{} for _ in range(5)]
-    successful['count'] = successful_count
-    successful['length'] = successful_length
-    unreported['count'] = unreported_count
-    unreported['length'] = unreported_length
-    match_errors['discontinuities'] = discontinuities_count
-    match_errors['partialseg_gt_2'] = partialseg_gt_2
-    stats['successful_matches'] = successful
-    stats['unreported_matches'] = unreported
-    stats['match_errors'] = match_errors
-    stats['invalid_speeds'] = invalid_speed_count
-    stats['unassociated_segments'] = unassociated_seg_count
-    
-    if not datastore_out['reports']:
-      datastore_out.pop('reports')
+    if len(datastore_out['reports']) == 0:
+      del datastore_out['reports']
 
+    data = {'stats':{'successful_matches':{}, 'unreported_matches':{}, 'match_errors':{}}}
     if shape_used:
       data['shape_used'] = shape_used
     data['segment_matcher'] = segments
     data['datastore'] = datastore_out
-    data['stats'] = stats
+
+    data['stats']['successful_matches']['count'] = successful_count
+    data['stats']['successful_matches']['length'] = successful_length
+    data['stats']['unreported_matches']['count'] = unreported_count
+    data['stats']['unreported_matches']['length'] = unreported_length
+    data['stats']['match_errors']['discontinuities'] = discontinuities_count
+    data['stats']['match_errors']['partialseg_gt_2'] = partialseg_gt_2
+    data['stats']['invalid_speeds'] = invalid_speed_count
+    data['stats']['unassociated_segments'] = unassociated_seg_count
     return json.dumps(data, separators=(',', ':'))
 
   #parse the request because we dont get this for free!

--- a/py/reporter_service.py
+++ b/py/reporter_service.py
@@ -132,7 +132,7 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
     segments['mode'] = 'auto'
     prior_segment_id = None
     first_seg = True
-    idx, successful_count, unreported_count, successful_length, unreported_length, discontinuities_count, partialseg_gt_2, invalid_speed_count, unassociated_seg_count = [0 for _ in range(9)]
+    idx, successful_count, unreported_count, successful_length, unreported_length, discontinuities_count, partialseg_gt_2, invalid_speed_count, unassociated_seg_count, internal_seg_count = [0 for _ in range(10)]
     datastore_out = {}
     datastore_out['mode'] = 'auto'
     datastore_out['reports'] = []
@@ -199,15 +199,18 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
 
       first_seg = False
       idx += 1
-      #Track segments that match to edges that do not have any OSMLR Id but are not internal (turn channel, roundabout, internal intersection) -
+      #Track segments that match to edges that do not have any OSMLR Id and are non-internal vs. internal (turn channel, roundabout, internal intersection) -
       #Likely a service road (driveway, alley, parking aisle, etc.)
-      if segment_id is None and internal == False:
-        unassociated_seg_count += 1
+      if segment_id is None:
+        if internal == False:
+          unassociated_seg_count += 1
+        else:
+          internal_seg_count += 1
 
     if len(datastore_out['reports']) == 0:
       del datastore_out['reports']
 
-    data = {'stats':{'successful_matches':{}, 'unreported_matches':{}, 'match_errors':{}}}
+    data = {'stats':{'successful_matches':{}, 'unreported_matches':{}, 'match_errors':{}, 'non_osmlr':{}}}
     if shape_used:
       data['shape_used'] = shape_used
     data['segment_matcher'] = segments
@@ -219,8 +222,9 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
     data['stats']['unreported_matches']['length'] = unreported_length
     data['stats']['match_errors']['discontinuities'] = discontinuities_count
     data['stats']['match_errors']['partialseg_gt_2'] = partialseg_gt_2
+    data['stats']['non_osmlr']['unassociated_segments'] = unassociated_seg_count
+    data['stats']['non_osmlr']['internal_segments'] = internal_seg_count
     data['stats']['invalid_speeds'] = invalid_speed_count
-    data['stats']['unassociated_segments'] = unassociated_seg_count
     return json.dumps(data, separators=(',', ':'))
 
   #parse the request because we dont get this for free!

--- a/py/reporter_service.py
+++ b/py/reporter_service.py
@@ -132,7 +132,7 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
     segments['mode'] = 'auto'
     prior_segment_id = None
     first_seg = True
-    idx, successful_count, unreported_count, successful_length, unreported_length, discontinuities_count, partialseg_gt_2, invalid_speed_count, unassociated_seg_count, internal_seg_count = [0 for _ in range(10)]
+    idx, successful_count, unreported_count, successful_length, unreported_length, discontinuities_count, partialseg_gt_2, invalid_speed_count, unassociated_seg_count, internal_seg_count, incomplete_seg_count = [0 for _ in range(11)]
     datastore_out = {}
     datastore_out['mode'] = 'auto'
     datastore_out['reports'] = []
@@ -183,6 +183,9 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
         else:
           unreported_count += 1
           unreported_length = (prior_length * 0.001) #convert meters to km
+      #log if prior segment is incomplete
+      else:
+        incomplete_seg_count += 1
 
       #Save state for next segment.
       if internal == True and first_seg != True:
@@ -220,11 +223,13 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
     data['stats']['successful_matches']['length'] = successful_length
     data['stats']['unreported_matches']['count'] = unreported_count
     data['stats']['unreported_matches']['length'] = unreported_length
+    data['stats']['incomplete_segments'] = incomplete_seg_count
     data['stats']['match_errors']['discontinuities'] = discontinuities_count
     data['stats']['match_errors']['partialseg_gt_2'] = partialseg_gt_2
     data['stats']['non_osmlr']['unassociated_segments'] = unassociated_seg_count
     data['stats']['non_osmlr']['internal_segments'] = internal_seg_count
     data['stats']['invalid_speeds'] = invalid_speed_count
+
     return json.dumps(data, separators=(',', ':'))
 
   #parse the request because we dont get this for free!


### PR DESCRIPTION
Added the following stats to the reporter:
stats: {
  successful_matches: {
      count: 62,  //count of successful matches being reported
      length: 0.478 (in km)
},
  match_errors: {
      discontinuities: 1,  //a count of the number of matches that include discontinuities
      invalid_speeds: 0,   //these are the speeds greater than the threashold
},
  unreported_matches: {
      count: 0,   // count of prior segments on local level not being reported
      length: 0 (in km)
},
unassociated_segments: 1  //non-internal non OSMLR segments
},