### PR TITLE
allow for keyed input via the cat script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       KAFKA_ADVERTISED_PORT: 9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       #these topics map directly to those in the kafka application
-      KAFKA_CREATE_TOPICS: "raw:1:1,formatted:4:1,batched:4:1"
+      KAFKA_CREATE_TOPICS: "raw:4:1,formatted:4:1,batched:4:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/py/cat_to_kafka.py
+++ b/py/cat_to_kafka.py
@@ -1,11 +1,8 @@
 #!/usr/bin/env python
 import sys
 import os
-import time
-import calendar
 import argparse
-import json
-import logging, time
+import logging
 from kafka import KafkaProducer
 from kafka.common import KafkaError
 
@@ -23,11 +20,14 @@ parser = argparse.ArgumentParser(description='Generate reporter post body', form
 parser.add_argument('file', metavar='F', type=str, nargs=1, help='A file name to be read from, use - for stdin')
 parser.add_argument('--bootstrap', type=str, help='A list of ip(s) and port(s) for your kafka bootstrap servers')
 parser.add_argument('--topic', type=str, help='Create a topic for which the messages should be associated')
+parser.add_argument('--key-with', type=str, help='A lambda of the form "lambda line: line.do_something()" such that the program can extract a key from a given line of input')
 
 args = parser.parse_args()
 args.file = args.file[0]
 
 producer = KafkaProducer(bootstrap_servers = args.bootstrap.split(','),api_version=(0, 10))
+exec('key_with = ' + (args.key_with if args.key_with else 'None'))
+
 
 #output a single body
 #for each line from stdin
@@ -35,10 +35,11 @@ handle = open(args.file, 'r') if args.file != '-' else sys.stdin
 for line in handle:
   #try to work on the line as normal
   try:
-   producer.send(args.topic, line.rstrip())
-  #we couldnt parse this line so lets output what we have so far
-  except:
-    pass
+   key = bytes(key_with(line)) if key_with else None
+   producer.send(args.topic, key = key, value = bytes(line.rstrip()))
+  except Exception as e:
+    sys.stderr.write(repr(e))
+    sys.stderr.write(os.linesep)
 #done
 if args.file != '-':
   producer.close()

--- a/py/cat_to_kafka.py
+++ b/py/cat_to_kafka.py
@@ -3,6 +3,7 @@ import sys
 import os
 import argparse
 import logging
+import json
 from kafka import KafkaProducer
 from kafka.common import KafkaError
 
@@ -27,7 +28,6 @@ args.file = args.file[0]
 
 producer = KafkaProducer(bootstrap_servers = args.bootstrap.split(','),api_version=(0, 10))
 exec('key_with = ' + (args.key_with if args.key_with else 'None'))
-
 
 #output a single body
 #for each line from stdin

--- a/py/make_requests.sh
+++ b/py/make_requests.sh
@@ -44,7 +44,7 @@ for file in ${files}; do
   #download in the foreground
   echo "Retrieving ${file} from s3" && aws s3 cp ${s3_dir}${file} . &> /dev/null
   #send to kafka producer
-  zcat ${file} | ./cat_to_kafka.py --bootstrap ${bootstrap} --topic ${topic} --key-with 'lambda line: line.split("|")[1]' -
+  zcat ${file} | sort | ./cat_to_kafka.py --bootstrap ${bootstrap} --topic ${topic} --key-with 'lambda line: line.split("|")[1]' -
   #done with this
   echo "Finished POST'ing ${file}" && rm -f ${file}
 done

--- a/py/make_requests.sh
+++ b/py/make_requests.sh
@@ -44,7 +44,7 @@ for file in ${files}; do
   #download in the foreground
   echo "Retrieving ${file} from s3" && aws s3 cp ${s3_dir}${file} . &> /dev/null
   #send to kafka producer
-  zcat ${file} | ./cat_to_kafka.py --bootstrap ${bootstrap} --topic ${topic} -
+  zcat ${file} | ./cat_to_kafka.py --bootstrap ${bootstrap} --topic ${topic} --key-with 'lambda line: line.split("|")[1]' -
   #done with this
   echo "Finished POST'ing ${file}" && rm -f ${file}
 done

--- a/tests/circle.sh
+++ b/tests/circle.sh
@@ -55,7 +55,7 @@ docker run \
   -e "KAFKA_ADVERTISED_HOST_NAME=${docker_ip}" \
   -e "KAFKA_ADVERTISED_PORT=${kafka_port}" \
   -e "KAFKA_ZOOKEEPER_CONNECT=zookeeper:${zookeeper_port}" \
-  -e "KAFKA_CREATE_TOPICS=raw:1:1,formatted:1:1,batched:4:1" \
+  -e "KAFKA_CREATE_TOPICS=raw:4:1,formatted:4:1,batched:4:1" \
   -v /var/run/docker.sock:/var/run/docker.sock \
   --name kafka \
   wurstmeister/kafka:latest
@@ -80,7 +80,7 @@ docker run \
 #
 sleep 10 #wait for the kafka worker to connect
 echo "Producing data to kafka" 
-py/cat_to_kafka.py --bootstrap localhost:9092 --topic raw valhalla_data/*.sv
+py/cat_to_kafka.py --bootstrap localhost:9092 --topic raw --key-with 'lambda line: line.split("|")[1]' valhalla_data/*.sv
 
 # done running stuff
 #


### PR DESCRIPTION
to be as parallel as possible we need the input topic to have more than one partition. to allow for this we need our scripts to key that topic by vehicle id. if we dont key do this we will get out of order points as they will be assigned randomly (not a problem if there is only one partition as they all randomly get the same partition).