### PR TITLE
add test for date parsing but it works..

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,11 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
 			<version>${kafka.version}</version>

--- a/py/make_requests.sh
+++ b/py/make_requests.sh
@@ -39,11 +39,12 @@ fi
 echo "Retrieving file list from s3"
 files=$(aws s3 ls ${s3_dir} | awk '{print $4}' | grep -E ${file_re} | tr '\n' ' ')
 echo "Processing $(echo ${files} | tr ' ' '\n' | wc -l) files"
-
+echo $files
 for file in ${files}; do
   #download in the foreground
   echo "Retrieving ${file} from s3" && aws s3 cp ${s3_dir}${file} . &> /dev/null
-  #send to kafka producer
+exit  
+#send to kafka producer
   zcat ${file} | sort | ./cat_to_kafka.py --bootstrap ${bootstrap} --topic ${topic} --key-with 'lambda line: line.split("|")[1]' -
   #done with this
   echo "Finished POST'ing ${file}" && rm -f ${file}

--- a/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
@@ -123,7 +123,8 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
           Segment segment = kv.value;
           if(kv.value.count >= privacy) {
             String tile_name =  Long.toString(key.time_range_start) + '_' +
-              Long.toString(key.time_range_start + quantisation - 1) + '/' + Long.toString(key.tile_level) + '/' + Long.toString(key.tile_id);
+              Long.toString(key.time_range_start + quantisation - 1) + '/' + 
+              Long.toString(key.getTileLevel()) + '/' + Long.toString(key.getTileId());
             StringBuffer tile = tiles.get(tile_name);
             //there wasnt already a tile made
             if(tile == null) {

--- a/src/main/java/io/opentraffic/reporter/BatchingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/BatchingProcessor.java
@@ -114,7 +114,8 @@ public class BatchingProcessor implements ProcessorSupplier<String, Point> {
                   report.get("length").asInt(), report.get("queue_length").asInt());
               //the key is the segment pair so processors will only ever see certain tiles
               //this seeks to maximize the number of possible segments in a given tile
-              context.forward(Long.toString(segment.id) + ' ' + 
+              if(segment.valid())
+                context.forward(Long.toString(segment.id) + ' ' + 
                   (segment.next_id != null ? Long.toString(segment.next_id) : "null"), segment);
             }
             catch(Exception e) {

--- a/src/main/java/io/opentraffic/reporter/Point.java
+++ b/src/main/java/io/opentraffic/reporter/Point.java
@@ -24,7 +24,27 @@ public class Point {
     this.accuracy = accuracy;
     this.time = time;
   }
-  
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Point other = (Point) obj;
+    if (accuracy != other.accuracy)
+      return false;
+    if (Float.floatToIntBits(lat) != Float.floatToIntBits(other.lat))
+      return false;
+    if (Float.floatToIntBits(lon) != Float.floatToIntBits(other.lon))
+      return false;
+    if (time != other.time)
+      return false;
+    return true;
+  }
+
   public static class Serder implements Serde<Point> {
     public static final DecimalFormat floatFormatter = new DecimalFormat("###.######", new DecimalFormatSymbols(Locale.US));
     public static void put(Point p, ByteBuffer buffer) {

--- a/src/main/java/io/opentraffic/reporter/Segment.java
+++ b/src/main/java/io/opentraffic/reporter/Segment.java
@@ -33,7 +33,7 @@ public class Segment {
     this.count = 1;
   }
   
-  public Segment(long id, long min, long max, int duration, int length, int queue, int count,  Long next_id) {
+  public Segment(long id, long min, long max, int duration, int length, int queue, int count, Long next_id) {
     this.id = id;
     this.next_id = next_id;
     this.min = min;
@@ -55,13 +55,8 @@ public class Segment {
     this.count += s.count;
   }
   
-  //first 3 bits are hierarchy level then 22 bits of tile id. the rest we want zero'd out
-  public long getTileId() {    
-    return (id >> 3) & 0x3FFFFF;
-  }
-  
-  public long getTileLevel() {
-    return id & 0x7;
+  public boolean valid() {
+    return count > 0 && min > 0 && max > 0 && duration > 0 && length > 0 && queue > 0;
   }
   
   public static String columnLayout() {

--- a/src/test/java/reporter/FormatterTest.java
+++ b/src/test/java/reporter/FormatterTest.java
@@ -1,0 +1,47 @@
+package reporter;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.opentraffic.reporter.Formatter;
+import io.opentraffic.reporter.Pair;
+import io.opentraffic.reporter.Point;
+
+public class FormatterTest {
+
+  @Test
+  public void testGetFormatter() {
+    Formatter.GetFormatter(",sv,\\|,1,9,10,0,5,yyyy-MM-dd HH:mm:ss");
+    Formatter.GetFormatter("@json@id@latitude@longitude@timestamp@accuracy");
+    
+    try { Formatter.GetFormatter("%sv%,%a"); fail("Bogus format"); }
+    catch(Exception e) { }
+    
+    try { Formatter.GetFormatter("%json%a%b%c%d"); fail("Bogus format"); }
+    catch(Exception e) { }
+    
+    try { Formatter.GetFormatter("bogus_formatter"); fail("Bogus format"); }
+    catch(Exception e) { }
+  }
+
+  @Test
+  public void testFormat() {
+    Formatter psv = Formatter.GetFormatter(",sv,\\|,1,9,10,0,5,yyyy-MM-dd HH:mm:ss");
+    Formatter json = Formatter.GetFormatter("@json@id@la@lo@t@a@yyyy-MM-dd HH:mm:ss");
+    
+    try {
+      Pair<String, Point> pp = psv.format("2017-01-01 06:05:40|w00t||||6.5||||0.0|0.0");
+      if(!pp.first.equals("w00t") || !pp.second.equals(new Point(0.0f, 0.0f, 7, 1483250740)))
+        fail("Wrong point");
+      
+      Pair<String, Point> jp = json.format("{\"t\":\"2017-01-01 06:05:40\",\"id\":\"w00t\",\"la\":0.0,\"lo\":0.0,\"a\":6.5}");
+      if(!jp.first.equals("w00t") || !jp.second.equals(new Point(0.0f, 0.0f, 7, 1483250740)))
+        fail("Wrong point");
+    }
+    catch(Exception e) {
+      fail("Couldn't parse");
+    }
+  }
+
+}


### PR DESCRIPTION
when doing our latest run with static data from jan 2017 we were noticing that the human readable text file time stamps were using numbers that would correlate to roughly some time in 1998. this pr will address this issue. so far its got a test to make sure the timestamp parsing is working, and it is. we'll check the other parts of the pipeline to see where its happening.