### PR TITLE
small cleanups

### DIFF
--- a/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
@@ -101,7 +101,14 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
           //keep this new one
           segments.add(value);
           //put it back in the store
-          store.put(tile, segments);
+          try {
+            store.put(tile, segments);
+          }//or fail and flush to sync
+          catch (Exception e) {
+            logger.error("Failed to store segments for tile flushing to sync: " + e.getMessage());
+            store.delete(tile);
+            store(tile, segments);
+          }
         }
       }
       
@@ -165,7 +172,7 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
           }
         }
         catch(Exception e) {
-          logger.error("Couldn't write " + tile_name + "/" + file_name + ": " + e.getMessage());
+          logger.error("Couldn't flush tile to sync " + tile_name + "/" + file_name + ": " + e.getMessage());
         }
       }
 
@@ -186,7 +193,7 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
         }
         it.close();
         //we purge the entire key value store, otherwise kvstore would have an enourmous long tail
-        store.flush();        
+        store.flush();
       }
 
       @Override

--- a/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
@@ -184,8 +184,9 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
           Collections.sort(kv.value);
           //delete segment pairs that dont meet the privacy requirement
           clean(kv.value);
-          //store this tile
-          store(kv.key, kv.value);
+          //store this tile if it has data
+          if(!kv.value.isEmpty())
+            store(kv.key, kv.value);
         }
         it.close();
         //we purge the entire key value store, otherwise kvstore would have an enourmous long tail

--- a/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
@@ -105,7 +105,7 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
             store.put(tile, segments);
           }//or fail and flush to sync
           catch (Exception e) {
-            logger.error("Failed to store segments for tile flushing to sync: " + e.getMessage());
+            logger.warn("Failed to store segments for tile, flushing to sync instead: " + e.getMessage());
             store.delete(tile);
             store(tile, segments);
           }
@@ -151,17 +151,17 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
         try {
           //put it to s3
           if(bucket) {
-            logger.debug("PUTting tile to " + output + '/' + tile_name + '/' + file_name);
+            logger.info("PUTting tile to " + output + '/' + tile_name + '/' + file_name);
             StringEntity body = new StringEntity(buffer.toString(), ContentType.create("text/plain", Charset.forName("UTF-8")));
             HttpClient.AwsPUT(output, tile_name + '/' + file_name, body, aws_key, aws_secret);
           }//post it to non s3
           else if(output.startsWith("http://") || output.startsWith("https://")) {
-            logger.debug("POSTing tile to " + output + '/' + tile_name + '/' + file_name);
+            logger.info("POSTing tile to " + output + '/' + tile_name + '/' + file_name);
             StringEntity body = new StringEntity(buffer.toString(), ContentType.create("text/plain", Charset.forName("UTF-8")));
             HttpClient.POST(output + '/' + file_name, body);
           }//write a new file in a dir
           else {
-            logger.debug("Writing tile to " + output + '/' + tile_name + '/' + file_name);
+            logger.info("Writing tile to " + output + '/' + tile_name + '/' + file_name);
             File dir = new File(output + '/' + tile_name);
             dir.mkdirs();
             File tile_file = new File(output + '/' + tile_name + '/' + file_name);

--- a/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
@@ -6,15 +6,11 @@ import java.io.FileWriter;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.UUID;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.http.Header;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.kafka.streams.KeyValue;

--- a/src/main/java/io/opentraffic/reporter/Formatter.java
+++ b/src/main/java/io/opentraffic/reporter/Formatter.java
@@ -34,7 +34,7 @@ public class Formatter {
   }
   
   public static Formatter GetFormatter(String format) {
-    logger.info("Formatting with: " + format);    
+    logger.debug("Formatting with: " + format);    
     String split_on = format.substring(0,1);
     format = format.substring(1);
     String[] args = format.split(split_on);

--- a/src/main/java/io/opentraffic/reporter/HttpClient.java
+++ b/src/main/java/io/opentraffic/reporter/HttpClient.java
@@ -14,6 +14,7 @@ import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpPost;
@@ -73,6 +74,12 @@ public final class HttpClient {
     CloseableHttpResponse response = null;
     String v = null;
     try {
+      //set some timeouts
+      RequestConfig.Builder builder = RequestConfig.custom();
+      builder.setConnectTimeout(1000);
+      builder.setConnectionRequestTimeout(1000);
+      builder.setSocketTimeout(10000);
+      request.setConfig(builder.build());
       //make the request
       CloseableHttpClient client = HttpClients.createDefault();
       response = client.execute(request);

--- a/src/main/java/io/opentraffic/reporter/KeyedFormattingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/KeyedFormattingProcessor.java
@@ -10,6 +10,7 @@ import org.apache.log4j.Logger;
 public class KeyedFormattingProcessor implements ProcessorSupplier<String, String> {
   private final static Logger logger = Logger.getLogger(KeyedFormattingProcessor.class);
   private Formatter formatter;
+  private long formatted;
   public KeyedFormattingProcessor(CommandLine cmd) {
     logger.debug("Instantiating keyed formatting processor");
     String format = cmd.getOptionValue("formatter");
@@ -24,6 +25,7 @@ public class KeyedFormattingProcessor implements ProcessorSupplier<String, Strin
       @Override
       public void init(ProcessorContext context) {
         this.context = context;
+        formatted = 0;
       }
 
       @Override
@@ -31,6 +33,9 @@ public class KeyedFormattingProcessor implements ProcessorSupplier<String, Strin
         try {
           Pair<String, Point> kv = formatter.format(value);
           context.forward(kv.first, kv.second);
+          formatted++;
+          if(formatted % 10000 == 0)
+            logger.info("Keyed and formatted " + formatted + " messages");
         } catch (Exception e) {
           logger.error("Could not key and format using, key = " + key + ", value = " + value);
         }

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -22,4 +22,4 @@ log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n
 
-log4j.logger.io.opentraffic.reporter=DEBUG
+log4j.logger.io.opentraffic.reporter=INFO

--- a/src/test/java/reporter/FormatterTest.java
+++ b/src/test/java/reporter/FormatterTest.java
@@ -1,6 +1,6 @@
 package reporter;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 


### PR DESCRIPTION
basically there are two main things im doing here.

the first is that we dont write tiles that have no segments in them. before we wrote the tile no matter what. this was happening because we'd have a tile with only a few segments in it and so because of the privacy threshold we would end up with none left and write an empty tile.

the second main issue is that when using the kafka key value store there is a 1 megabyte limit imposed on any one value. this is fine for most of the places we use the key value store. for example we use it to store a small window of points of a single vehicles trace, we use it to store segment pairs. those are very small amounts of data. but we also use it to store all the segments in a tile. this is a problem. we can get a lot of observations for a given area over a given period of time. and when that happens and we try to write the data back to the store it throws an exception. so we now catch that and write the tile to the datastore (s3,http,disk). the other option would be that we configure the brokers or whatever in kafka to allow for larger values but the trick here is that you'd have to know what those will be! what this amounts to is that we may end up throwing out some values because when we run out of space to store the tiles data some of the observations might not have had enough privacy yet. this can be fixed an ill do it in another pr or another commit (we'll see).

other than that i did some work on the logging to be only the important stuff at INFO level and set that as the default.