### PR TITLE
dont call punctuate from close (#99)

### DIFF
--- a/py/reporter_service.py
+++ b/py/reporter_service.py
@@ -172,7 +172,8 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
           else:
             #Excessive speed - log this as an error
             sys.stderr.write("Speed exceeds 200kph\n")
-            #sys.stderr.write(json.dumps(trace))
+            #sys.stderr.write(json.dumps(trace) + '\n')
+            sys.stderr.flush()
             invalid_speed_count += 1
         #Log prior segments on local level not being reported; lets do a count and track prior_segment_ids
         else:

--- a/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
@@ -263,7 +263,6 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
 
       @Override
       public void close() {
-        punctuate(0);
       }
       
     };

--- a/src/main/java/io/opentraffic/reporter/BatchingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/BatchingProcessor.java
@@ -81,26 +81,20 @@ public class BatchingProcessor implements ProcessorSupplier<String, Point> {
       @Override
       public void punctuate(long timestamp) {
         //find which ones need to go
-        HashSet<String> to_delete = new HashSet<String>();
         KeyValueIterator<String, Batch> it = store.all();
         while(it.hasNext()) {
           KeyValue<String, Batch> kv = it.next();
-          if(kv != null && (kv.value == null || timestamp - kv.value.last_update > SESSION_GAP))
-            to_delete.add(kv.key);
-        }
-        it.close();
-        
-        //off to the glue factory with you guys
-        for(String key : to_delete) {
-          //TODO: dont actually report here, instead insert into a queue that a thread can drain asynchronously
-          logger.debug("Evicting " + key + " as it was stale");
-          Batch batch = store.delete(key);
-          if(batch != null) {
-            int reported = forward(batch.report(key, url, 0, 2, 0));
+          //off to the glue factory with you
+          if(kv.value == null || timestamp - kv.value.last_update > SESSION_GAP) {
+            logger.debug("Evicting " + kv.key + " as it was stale");
+            store.delete(kv.key);
+            //report what we can
+            int reported = forward(kv.value.report(kv.key, url, 0, 2, 0));
             if(reported > 0)
               logger.debug("Reported on " + reported + " segment pairs during eviction");
           }
         }
+        it.close();
       }
       
       private int forward(JsonNode result) {
@@ -140,8 +134,6 @@ public class BatchingProcessor implements ProcessorSupplier<String, Point> {
   
       @Override
       public void close() {
-        //take care of the rest of the stuff thats hanging around
-        punctuate(Long.MAX_VALUE);
       }
     };
   }


### PR DESCRIPTION
* dont call punctuate from close, the kvstore will keep the data around for the next worker to use

* we learned to delete while iterating from the anonymising processor

* fix 200kph print

* simplify