### PR TITLE
add simple script-based reporter

### DIFF
--- a/py/reporter_service.py
+++ b/py/reporter_service.py
@@ -79,6 +79,112 @@ class ThreadPoolMixIn(ThreadingMixIn):
 class ThreadedHTTPServer(ThreadPoolMixIn, HTTPServer):
   pass
 
+#report some segments for the datastore
+def report(segments, trace, threshold_sec, report_levels, transition_levels):
+  #Get the end time
+  end_time = trace['trace'][len(trace['trace']) - 1]['time']
+
+  #Walk from the last segment until a segment is found where the difference between
+  #the end time and the segment begin time exceeds the threshold
+  last_idx = len(segments['segments'])-1
+  while last_idx >= 0 and end_time - segments['segments'][last_idx]['start_time'] < threshold_sec:
+    last_idx -= 1
+
+  #Trim shape to the beginning of the last segment
+  shape_used = None
+  if last_idx >= 0:
+    shape_used = segments['segments'][last_idx]['begin_shape_index']
+
+  #Compute values to send to the datastore: start time for a segment
+  #next segment (if any), start time at the next segment (end time of segment if no next segment)
+  segments['mode'] = 'auto'
+  prior_segment_id = None
+  first_seg = True
+  idx, successful_count, unreported_count, successful_length, unreported_length, discontinuities_count, invalid_speed_count, unassociated_seg_count = [0 for _ in range(8)]
+  datastore_out = {}
+  datastore_out['mode'] = 'auto'
+  datastore_out['reports'] = []
+  while idx <= last_idx:
+    seg = segments['segments'][idx]
+    segment_id = seg.get('segment_id')
+    way_ids = seg.get('way_ids')
+    start_time = seg.get('start_time')
+    end_time = seg.get('end_time')
+    #internal means the segment is an internal intersection, turn channel, roundabout
+    internal = seg.get('internal', False)
+    queue_length = seg.get('queue_length')
+    #length = -1 means this is a partial OSMLR segment match
+    length = seg.get('length')
+    #report a count of the number of matches that include discontinuities (a partial end time followed by a partial start time that are consecutive) as invalid
+    if idx != 0 and segments['segments'][idx]['start_time'] == -1 and segments['segments'][idx-1]['end_time'] == -1:
+      discontinuities_count += 1
+
+    #check if segment Id is on the local level
+    level = (segment_id & 0x7) if segment_id != None else -1
+
+    #Conditionally output prior segment if it is complete and the level is configured to be reported
+    if prior_segment_id != None and prior_length > 0 and internal != True:
+      if prior_level in report_levels:
+        #Add the prior segment.
+        report = {'id': prior_segment_id, 't0' : prior_start_time, 't1' : (start_time if level in transition_levels else prior_end_time), 'length' : prior_length, 'queue_length' : prior_queue_length }
+        if level in transition_levels and segment_id is not None:
+          report['next_id'] = segment_id
+
+        #Validate start and end times and ensure speed is not too high
+        if report['t1'] - report['t0'] <= 0:
+          sys.stderr.write("Time is <= 0 - do not report\n")
+          #sys.stderr.write(json.dumps(trace))
+        elif (prior_length / (report['t1'] - report['t0'])) * 3.6 < 160:
+          datastore_out['reports'].append(report)
+          successful_count += 1
+          successful_length = round((prior_length * 0.001),3) #convert meters to km
+        else:
+          #Excessive speed - log this as an error
+          sys.stderr.write("Speed exceeds 200kph\n")
+          #sys.stderr.write(json.dumps(trace) + '\n')
+          sys.stderr.flush()
+          invalid_speed_count += 1
+      #Log prior segments on local level not being reported; lets do a count and track prior_segment_ids
+      else:
+        unreported_count += 1
+        unreported_length = round((prior_length * 0.001),3) #convert meters to km
+
+    #Save state for next segment.
+    if internal == True and first_seg != True:
+      #Do not replace information on prior segment, except to mark the prior as internal
+      prior_internal = internal
+    else:
+      prior_segment_id = segment_id
+      prior_start_time = start_time
+      prior_end_time = end_time
+      prior_internal = internal
+      prior_length = length
+      prior_level = level
+      prior_queue_length = queue_length
+
+    first_seg = False
+    idx += 1
+    #Track segments that match to edges that do not have any OSMLR Id and are non-internal (turn channel, roundabout, internal intersection) -
+    #Likely a service road (driveway, alley, parking aisle, etc.)
+    if segment_id is None and internal == False:
+      unassociated_seg_count += 1
+
+  data = {'stats':{'successful_matches':{}, 'unreported_matches':{}, 'match_errors':{}}}
+  if shape_used:
+    data['shape_used'] = shape_used
+  data['segment_matcher'] = segments
+  data['datastore'] = datastore_out
+
+  data['stats']['successful_matches']['count'] = successful_count
+  data['stats']['successful_matches']['length'] = successful_length
+  data['stats']['unreported_matches']['count'] = unreported_count
+  data['stats']['unreported_matches']['length'] = unreported_length
+  data['stats']['match_errors']['discontinuities'] = discontinuities_count
+  data['stats']['match_errors']['invalid_speeds'] = invalid_speed_count
+  data['stats']['unassociated_segments'] = unassociated_seg_count
+
+  return data
+
 #custom handler for getting routes
 class SegmentMatcherHandler(BaseHTTPRequestHandler):
   #boiler plate parsing
@@ -106,116 +212,6 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
     raise Exception('No json provided')
 
 
-  #report some segments to the datastore
-  def report(self, trace):
-    #ask valhalla to give back OSMLR segments along this trace
-    result = thread_local.segment_matcher.Match(json.dumps(trace, separators=(',', ':')))
-    segments = json.loads(result)
-
-    #Get the end time
-    end_time = trace['trace'][len(trace['trace']) - 1]['time']
-
-    #Walk from the last segment until a segment is found where the difference between
-    #the end time and the segment begin time exceeds the threshold
-    last_idx = len(segments['segments'])-1
-    while last_idx >= 0 and end_time - segments['segments'][last_idx]['start_time'] < thread_local.threshold_sec:
-      last_idx -= 1
-
-    #Trim shape to the beginning of the last segment
-    shape_used = None
-    if last_idx >= 0:
-      shape_used = segments['segments'][last_idx]['begin_shape_index']
-
-    #Compute values to send to the datastore: start time for a segment
-    #next segment (if any), start time at the next segment (end time of segment if no next segment)
-    segments['mode'] = 'auto'
-    prior_segment_id = None
-    first_seg = True
-    idx, successful_count, unreported_count, successful_length, unreported_length, discontinuities_count, invalid_speed_count, unassociated_seg_count = [0 for _ in range(8)]
-    datastore_out = {}
-    datastore_out['mode'] = 'auto'
-    datastore_out['reports'] = []
-    while idx <= last_idx:
-      seg = segments['segments'][idx]
-      segment_id = seg.get('segment_id')
-      way_ids = seg.get('way_ids')
-      start_time = seg.get('start_time')
-      end_time = seg.get('end_time')
-      #internal means the segment is an internal intersection, turn channel, roundabout
-      internal = seg.get('internal', False)
-      queue_length = seg.get('queue_length')
-      #length = -1 means this is a partial OSMLR segment match
-      length = seg.get('length')
-      #report a count of the number of matches that include discontinuities (a partial end time followed by a partial start time that are consecutive) as invalid
-      if idx != 0 and segments['segments'][idx]['start_time'] == -1 and segments['segments'][idx-1]['end_time'] == -1:
-        discontinuities_count += 1
-
-      #check if segment Id is on the local level
-      level = (segment_id & 0x7) if segment_id != None else -1
-
-      #Conditionally output prior segment if it is complete and the level is configured to be reported
-      if prior_segment_id != None and prior_length > 0 and internal != True:
-        if prior_level in thread_local.report_levels:
-          #Add the prior segment.
-          report = {'id': prior_segment_id, 't0' : prior_start_time, 't1' : (start_time if level in thread_local.transition_levels else prior_end_time), 'length' : prior_length, 'queue_length' : prior_queue_length }
-          if level in thread_local.transition_levels and segment_id is not None:
-            report['next_id'] = segment_id
-
-          #Validate start and end times and ensure speed is not too high
-          if report['t1'] - report['t0'] <= 0:
-            sys.stderr.write("Time is <= 0 - do not report\n")
-            #sys.stderr.write(json.dumps(trace))
-          elif (prior_length / (report['t1'] - report['t0'])) * 3.6 < 160:
-            datastore_out['reports'].append(report)
-            successful_count += 1
-            successful_length = round((prior_length * 0.001),3) #convert meters to km
-          else:
-            #Excessive speed - log this as an error
-            sys.stderr.write("Speed exceeds 200kph\n")
-            #sys.stderr.write(json.dumps(trace) + '\n')
-            sys.stderr.flush()
-            invalid_speed_count += 1
-        #Log prior segments on local level not being reported; lets do a count and track prior_segment_ids
-        else:
-          unreported_count += 1
-          unreported_length = round((prior_length * 0.001),3) #convert meters to km
-
-      #Save state for next segment.
-      if internal == True and first_seg != True:
-        #Do not replace information on prior segment, except to mark the prior as internal
-        prior_internal = internal
-      else:
-        prior_segment_id = segment_id
-        prior_start_time = start_time
-        prior_end_time = end_time
-        prior_internal = internal
-        prior_length = length
-        prior_level = level
-        prior_queue_length = queue_length
-
-      first_seg = False
-      idx += 1
-      #Track segments that match to edges that do not have any OSMLR Id and are non-internal (turn channel, roundabout, internal intersection) -
-      #Likely a service road (driveway, alley, parking aisle, etc.)
-      if segment_id is None and internal == False:
-        unassociated_seg_count += 1
-
-    data = {'stats':{'successful_matches':{}, 'unreported_matches':{}, 'match_errors':{}}}
-    if shape_used:
-      data['shape_used'] = shape_used
-    data['segment_matcher'] = segments
-    data['datastore'] = datastore_out
-
-    data['stats']['successful_matches']['count'] = successful_count
-    data['stats']['successful_matches']['length'] = successful_length
-    data['stats']['unreported_matches']['count'] = unreported_count
-    data['stats']['unreported_matches']['length'] = unreported_length
-    data['stats']['match_errors']['discontinuities'] = discontinuities_count
-    data['stats']['match_errors']['invalid_speeds'] = invalid_speed_count
-    data['stats']['unassociated_segments'] = unassociated_seg_count
-
-    return json.dumps(data, separators=(',', ':'))
-
   #parse the request because we dont get this for free!
   def handle_request(self, post):
     #get the trace data
@@ -237,7 +233,11 @@ class SegmentMatcherHandler(BaseHTTPRequestHandler):
 
     #possibly report on what we have
     try:
-      return 200, self.report(trace)
+      #ask valhalla to give back OSMLR segments along this trace
+      result = thread_local.segment_matcher.Match(json.dumps(trace, separators=(',', ':')))
+      match = json.loads(result)
+      data = report(match, trace, thread_local.threshold_sec, thread_local.report_levels, thread_local.transition_levels)
+      return 200, json.dumps(data, separators=(',', ':'))
     except Exception as e:
       return 500, '{"error":"' + str(e) + '"}'
 

--- a/py/simple_reporter.py
+++ b/py/simple_reporter.py
@@ -197,8 +197,9 @@ def match(file_name, time_pattern, quantisation, source, dest_dir):
     return
   
   #weed out the usable segments and then send them off to the time tiles
-  segments = [ r for r in report['datastore']['reports'] if r['t0'] > 0 and r['t1'] > 0 and r['t1'] > r['t0'] and r['length'] > 0 and r['queue_length'] >= 0 ]
+  segments = [ r for r in report['datastore']['reports'] if r['t0'] > 0 and r['t1'] > 0 and r['t1'] - r['t0'] > .5 and r['length'] > 0 and r['queue_length'] >= 0 ]
   for r in segments:
+    duration = int(round(r['t1'] - r['t0']))
     start = int(math.floor(r['t0']))
     end = int(math.ceil(r['t1']))
     min_bucket = int(start / quantisation)
@@ -214,7 +215,7 @@ def match(file_name, time_pattern, quantisation, source, dest_dir):
         s = [
           str(r['id']),
           str(r.get('next_id', INVALID_SEGMENT_ID)),
-          str(int(round(r['t1'] - r['t0']))),
+          str(duration),
           '1',
           str(r['length']),
           str(r['queue_length']),

--- a/py/simple_reporter.py
+++ b/py/simple_reporter.py
@@ -199,8 +199,8 @@ def match(file_name, time_pattern, quantisation, source, dest_dir):
   #weed out the usable segments and then send them off to the time tiles
   segments = [ r for r in report['datastore']['reports'] if r['t0'] > 0 and r['t1'] > 0 and r['t1'] > r['t0'] and r['length'] > 0 and r['queue_length'] >= 0 ]
   for r in segments:
-    start = math.floor(r['t0'])
-    end = math.ceil(r['t1'])
+    start = int(math.floor(r['t0']))
+    end = int(math.ceil(r['t1']))
     min_bucket = int(start / quantisation)
     max_bucket = int(end / quantisation)
     for b in range(min_bucket, max_bucket + 1):
@@ -221,7 +221,7 @@ def match(file_name, time_pattern, quantisation, source, dest_dir):
           str(start),
           str(end),
           source,
-          'auto'
+          'AUTO'
         ]
         f.write(','.join(s) + os.linesep)
 

--- a/py/simple_reporter.py
+++ b/py/simple_reporter.py
@@ -145,8 +145,8 @@ def get_traces(bucket, prefix, regex, keyer, valuer, bbox, threads):
   filtered = filter(regex.match, keys)
   
   #download and parse them into proper files
-  logger.info('Gathering trace data from source files')
   dest_dir = tempfile.mkdtemp(dir='')
+  logger.info('Gathering trace data from source files into %s' % dest_dir)
   pool = ThreadPool(threads, local_session)
   total = 0.0
   for key in filtered:
@@ -232,10 +232,10 @@ def local_matcher():
 
 def make_matches(trace_dir, config, time_pattern, quantisation, source, threads):
   #download and parse them into proper files
-  logger.info('Matching trace data to osmlr segments')
+  dest_dir = tempfile.mkdtemp(dir='')
+  logger.info('Matching trace data to osmlr segments into %s' % dest_dir)
   valhalla.Configure(config)
   pool = ThreadPool(threads, local_matcher)
-  dest_dir = tempfile.mkdtemp(dir='')
   total = 0.0
   for root, dirs, files in os.walk(trace_dir):
     for file_name in files:

--- a/py/simple_reporter.py
+++ b/py/simple_reporter.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python2
+
+import argparse
+import boto3
+import urllib
+import functools
+import os
+import re
+import logging
+import gzip
+import cStringIO
+import Queue
+import multiprocessing
+import threading
+import tempfile
+import hashlib
+import time
+import calendar
+import math
+import json
+import valhalla
+import reporter_service
+
+thread_local = threading.local()
+
+logger = logging.getLogger('convert')
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)s'))
+logger.addHandler(handler)
+
+valhalla_tiles = [{'level': 2, 'size': 0.25}, {'level': 1, 'size': 1.0}, {'level': 0, 'size': 4.0}]
+LEVEL_BITS = 3
+TILE_INDEX_BITS = 22
+SEGMENT_INDEX_BITS = 21
+LEVEL_MASK = (2**LEVEL_BITS) - 1
+TILE_INDEX_MASK = (2**TILE_INDEX_BITS) - 1
+SEGMENT_INDEX_MASK = (2**SEGMENT_INDEX_BITS) - 1
+INVALID_SEGMENT_ID = (SEGMENT_INDEX_MASK << (TILE_INDEX_BITS + LEVEL_BITS)) | (TILE_INDEX_MASK << LEVEL_BITS) | LEVEL_MASK
+
+def get_tile_level(segment_id):
+  return segment_id & LEVEL_MASK
+
+def get_tile_index(segment_id):
+  return (segment_id >> LEVEL_BITS) & TILE_INDEX_MASK
+
+class Worker(threading.Thread):
+  def __init__(self, tasks, results, local_init):
+    threading.Thread.__init__(self)
+    self.tasks = tasks
+    self.results = results
+    self.daemon = True
+    self.local_init = local_init
+    self.start()
+  def run(self):
+    self.local_init()
+    while True:
+      func, args, kargs = self.tasks.get()
+      try:
+        result = func(*args, **kargs)
+        if result is not None:
+          self.results.put(result)
+      except Exception as e: logger.error(e)
+      finally: self.tasks.task_done()
+
+class ThreadPool:
+  def __init__(self, num_threads, thread_local_init=lambda:None):
+    self.tasks = Queue.Queue(0)
+    self.results = Queue.Queue(0)
+    for _ in range(num_threads): Worker(self.tasks, self.results, thread_local_init)
+  def add_task(self, func, *args, **kargs):
+    self.tasks.put((func, args, kargs))
+  def join(self):
+    self.tasks.join()
+    return list(self.results.queue)
+  def queue_size(self):
+    return self.tasks.qsize()
+
+def get_prefixes_keys(client, bucket, prefixes):
+  keys = []
+  pres = []
+  for prefix in prefixes:
+    token = None
+    first = True
+    while first or token:
+      if token:
+        objects = client.list_objects_v2(Bucket=bucket, Delimiter='/', Prefix=prefix, ContinuationToken=token)
+      else:
+        objects = client.list_objects_v2(Bucket=bucket, Delimiter='/', Prefix=prefix)
+      if 'Contents' in objects:
+        keys.extend([ o['Key'] for o in objects['Contents'] ])
+      if 'CommonPrefixes' in objects:
+        pres.extend([ o['Prefix'] for o in objects['CommonPrefixes'] ])
+      token = objects.get('NextContinuationToken')
+      first = False
+  return pres, keys
+
+def download(bucket, key, keyer, valuer, dest_dir):
+  #go get it
+  try:
+    file_name = hashlib.sha1(key).hexdigest()
+    thread_local.client.download_file(bucket, key, file_name)
+    logging.info('Downloaded %s' % key)
+    with gzip.open(file_name, 'rb') as f:
+      for message in f:
+        #hash the id part and get the values out
+        key_file = keyer(message)
+        key_file = '00' + hashlib.sha1(key_file).hexdigest()
+        chars = list(key_file)
+        for i in range(0, 14):
+          chars.insert(i * 3 + i, '/')
+        key_file = dest_dir + ''.join(chars)
+        value = valuer(message)
+        #append them to a file
+        try: os.makedirs(os.sep.join(key_file.split('/')[:-1]))
+        except: pass
+        with open(key_file, 'a', 1) as kf:
+          kf.write(','.join(value) + os.linesep)
+    logging.info('Gathered traces from %s' % key)
+    os.remove(file_name)
+  except Exception as e:
+    logger.error('%s was not processed %s' % (key, e))
+  
+def local_session():
+  setattr(thread_local, 'session', boto3.session.Session())
+  setattr(thread_local, 'client', thread_local.session.client('s3'))
+
+def get_traces(bucket, prefix, regex, keyer, valuer, threads):
+  logger.info('Getting source data keys from bucket %s using prefix %s' % (bucket, prefix))
+  #get the proper keys we care about
+  _, keys = get_prefixes_keys(boto3.client('s3'), bucket, [prefix])
+  filtered = filter(regex.match, keys)
+  filtered = filtered[:2]
+  
+  #download and parse them into proper files
+  logger.info('Gathering trace data from %d source files after filtering using %s' % (len(filtered), regex.pattern))
+  dest_dir = tempfile.mkdtemp(dir='')
+  pool = ThreadPool(threads, local_session)
+  total = 0.0
+  for key in filtered:
+    pool.add_task(download, bucket, key, keyer, valuer, dest_dir)
+    total += 1
+
+  #monitor progress
+  progress = -1
+  while pool.queue_size() > 0:
+   p = int((1.0 - (pool.queue_size() / total)) * 10) * 10
+   if p > progress:
+     logger.info('Gathering traces %d%%' % p)
+     progress = p
+   time.sleep(1)
+  pool.join()
+  if progress != 100:
+    logger.info('Gathering traces 100%')
+  logger.info('Done gathering traces')
+  return dest_dir
+  
+def match(file_name, time_pattern, quantisation, source, dest_dir):
+  #get out the data into a request payload
+  trace = { 'uuid': file_name, 'trace': [] }
+  with open(file_name, 'r') as f:
+    for line in f:
+      tm, lat, lon, acc = tuple(line.strip().split(','))
+      tm = calendar.timegm(time.strptime(tm, time_pattern))
+      trace['trace'].append({'lat': float(lat), 'lon': float(lon), 'time': tm, 'accuracy': int(math.ceil(float(acc)))})
+
+  #sort the points by time in case threads were competing on the file
+  trace['trace'].sort(key=lambda v:v['time'])
+  report_levels = set([0, 1])
+  transition_levels = set([0, 1])
+  threshold_sec = 15
+  
+  #get the matches for it
+  match_str = thread_local.segment_matcher.Match(json.dumps(trace, separators=(',', ':')))
+  match = json.loads(match_str)
+  report = reporter_service.report(match, trace, threshold_sec, report_levels, transition_levels)
+  
+  #weed out the usable segments and then send them off to the time tiles
+  segments = [ r for r in report['datastore']['reports'] if r['t0'] > 0 and r['t1'] > 0 and r['t1'] > r['t0'] and r['length'] > 0 and r['queue_length'] >= 0 ]
+  for r in segments:
+    start = math.floor(r['t0'])
+    end = math.ceil(rs['t1'])
+    min_bucket = int(start / quantisation)
+    max_bucket = int(end / quantisation)
+    for b in range(min_bucket, max_bucket + 1):
+      tile_level = str(get_tile_level(r['id']))
+      tile_index = str(get_tile_index(r['id']))
+      file_name = dest_dir + os.sep + str(b * quantisation) + '_' + str((b + 1) * quantisation - 1) + os.sep + tile_level + os.sep + tile_index
+      #append to a file
+      try: os.makedirs(os.sep.join(file_name.split(os.sep)[:-1]))
+      except: pass
+      with open(file_name, 'a', 1) as f:
+        s = [
+          str(s['id']),
+          str(s.get('next_id', INVALID_SEGMENT_ID)),
+          str(int(round(r['t1'] - r['t0']))),
+          '1',
+          str(r['length']),
+          str(r['queue_length']),
+          str(start),
+          str(end),
+          source,
+          'auto'
+        ]
+        f.write(','.join(s) + os.linesep)
+
+def local_matcher():
+  setattr(thread_local, 'segment_matcher', valhalla.SegmentMatcher())
+
+def make_matches(trace_dir, config, time_pattern, quantisation, source, threads):
+  #download and parse them into proper files
+  logger.info('Matching trace data to osmlr segments')
+  valhalla.Configure(config)
+  pool = ThreadPool(threads, local_matcher)
+  dest_dir = tempfile.mkdtemp(dir='')
+  total = 0.0
+  for root, dirs, files in os.walk(trace_dir):
+    for file_name in files:
+      pool.add_task(match, root + os.sep + file_name, time_pattern, quantisation, source, dest_dir)
+      total += 1
+
+  #monitor progress
+  progress = -1
+  while pool.queue_size() > 0:
+   p = int((1.0 - (pool.queue_size() / total)) * 20) * 5
+   if p > progress:
+     logger.info('Matching trace data %d%%' % p)
+     progress = p
+   time.sleep(1)
+  pool.join()
+  if progress != 100:
+    logger.info('Matching trace data 100%')
+  logger.info('Done matching trace data')
+  return dest_dir
+  
+def report(file_name, bucket, privacy):
+  #sort the data for this tile
+  with open(file_name, 'r') as f:
+    segments = f.readlines()
+  segments.sort()
+
+  #cull the entries that dont meet the privacy requirements
+  start = 0
+  i = 0
+  while i < len(segments):
+    s = segments[start].split(',')
+    e = segments[i].split(',')
+    #we are onto a new range or the last one
+    if s[0] != e[0] or s[1] != e[1] or i == len(segments) - 1:
+      #if its the last range we need i to be as if its the next segment pair
+      if i == len(segments) - 1:
+        i += 1
+      #didnt make the cut
+      if i - start < privacy:
+        segments[start: i] = []
+        i = start
+      #did make the cut
+      else:
+        start = i
+    #next
+    i += 1
+
+  #write the lines to a file like object and upload it
+  with cStringIO.StringIO() as f:
+    f.write('segment_id,next_segment_id,duration,count,length,queue_length,minimum_timestamp,maximum_timestamp,source,vehicle_type' + os.linesep)
+    for s in segments:
+      f.write(s)
+    thread_local.client.put_object(
+      Bucket=bucket,
+      Body=f.getvalue(),
+      Key='/'.join(file_name.split(os.sep)[1:]) + '/' + hashlib.sha1(file_name).hexdigest())  
+
+def report_tiles(match_dir, bucket, privacy, threads):
+  #download and parse them into proper files
+  logger.info('Reporting anonymised time tiles')
+  pool = ThreadPool(threads, local_session)
+  total = 0.0
+  for root, dirs, files in os.walk(match_dir):
+    for file_name in files:
+      pool.add_task(report, root + os.sep + file_name, bucket, privacy)
+      total += 1
+
+  #monitor progress
+  progress = -1
+  while pool.queue_size() > 0:
+   p = int((1.0 - (pool.queue_size() / total)) * 20) * 5
+   if p > progress:
+     logger.info('Reporting tiles %d%%' % p)
+     progress = p
+   time.sleep(1)
+  pool.join()
+  if progress != 100:
+    logger.info('Reporting tiles 100%')
+  logger.info('Done reporting tiles')
+  return dest_dir
+
+if __name__ == '__main__':
+  #build args
+  parser = argparse.ArgumentParser()
+  parser.add_argument('--src-bucket', type=str, help='Bucket where to get the input trace data from', required=True)
+  parser.add_argument('--src-prefix', type=str, help='Bucket prefix for getting source data', required=True)
+  parser.add_argument('--src-key-regex', type=str, help='Bucket key regex for getting source data', default='.*')
+  parser.add_argument('--src-keyer', type=str, help='A lambda used to extract the key from a given message in the input', default='lambda l: l.split("|")[1]')
+  parser.add_argument('--src-valuer', type=str, help='A lambda used to extract the time, lat, lon, accuracy from a given message in the input', default='lambda l: functools.partial(lambda c: [c[0], c[9], c[10], c[5] ], l.split("|"))()')
+  parser.add_argument('--src-time-pattern', type=str, help='A string used to extract epoch seconds from a time string', default='%Y-%m-%d %H:%M:%S')
+  parser.add_argument('--match-config', type=str, help='A file containing the config for the map matcher', required=True)
+  parser.add_argument('--quantisation', type=int, help='How large are the buckets to make tiles for. They should always be an hour (3600 seconds)', default=3600)
+  parser.add_argument('--privacy', type=int, help='How many readings of a given segment pair must appear before it being reported', default=2)
+  parser.add_argument('--source-id', type=str, help='A simple string to identify where these readings came from', default='smpl_rprt')
+  parser.add_argument('--dest-bucket', type=str, help='Bucket where we want to put the reporter output', required=True)
+  parser.add_argument('--concurrency', type=int, help='Number of threads to use when doing various stages of processing', default=multiprocessing.cpu_count())
+  args = parser.parse_args()
+
+  #fetch the data and divide it up
+  exec('keyer = ' + args.src_keyer)
+  exec('valuer = ' + args.src_valuer)
+  trace_dir = get_traces(args.src_bucket, args.src_prefix, re.compile(args.src_key_regex), keyer, valuer, args.concurrency)
+
+  #do matching on every file
+  match_dir = make_matches(trace_dir, args.match_config, args.src_time_pattern, args.quantisation, args.source_id, args.concurrency)
+
+  #filter and upload all the data
+  report_tiles(match_dir, args.dest_bucket, args.privacy, args.concurrency)
+
+  #clean up the data
+  #os.remove(src_dir)
+  #os.remove(match_dir)

--- a/src/main/java/io/opentraffic/reporter/Segment.java
+++ b/src/main/java/io/opentraffic/reporter/Segment.java
@@ -16,33 +16,18 @@ public class Segment implements Comparable<Segment>{
   public static long INVALID_SEGMENT_ID = 0x3fffffffffffL;
   public long id;         //main segment id
   public long next_id;    //optional next, could be invalid
-  public long min, max;   //epoch seconds
-  public int duration;    //epoch seconds
+  public double min, max; //epoch seconds
   public int length;      //meters
   public int queue;       //meters
-  public int count;       //how many
-  public static final int SIZE = 8 + 8 + 8 + 8 + 4 + 4 + 4 + 4;
+  public static final int SIZE = 8 + 8 + 8 + 8 + 4 + 4;
   
   public Segment(long id, Long next_id, double start, double end, int length, int queue) {
     this.id = id;
     this.next_id = next_id == null ? INVALID_SEGMENT_ID : next_id;
-    this.min = (long)Math.floor(start);
-    this.max = (long)Math.ceil(end);
-    this.duration = (int)Math.round(end - start);
+    this.min = start;
+    this.max = end;
     this.length = length;
     this.queue = queue;
-    this.count = 1;
-  }
-  
-  public Segment(long id, Long next_id, long min, long max, int duration, int length, int queue, int count) {
-    this.id = id;
-    this.next_id = next_id == null ? INVALID_SEGMENT_ID : next_id;
-    this.min = min;
-    this.max = max;
-    this.duration = duration;
-    this.length = length;
-    this.queue = queue;
-    this.count = 1;
   }
   
   //first 3 bits are hierarchy level then 22 bits of tile id. the rest we want zero'd out
@@ -51,7 +36,7 @@ public class Segment implements Comparable<Segment>{
   }
   
   public boolean valid() {
-    return count > 0 && min > 0 && max > 0 && duration > 0 && length > 0 && queue >= 0;
+    return min > 0 && max > 0 && max > min && length > 0 && queue >= 0;
   }
   
   @Override
@@ -77,12 +62,13 @@ public class Segment implements Comparable<Segment>{
     if(next_id != INVALID_SEGMENT_ID)
       buffer.append(next_id);
     buffer.append(',');
-    buffer.append(Integer.toString(duration)); buffer.append(',');
-    buffer.append(Integer.toString(count)); buffer.append(',');
+    Double duration = new Double(Math.round(max-min));
+    buffer.append(Integer.toString(duration.intValue())); buffer.append(',');
+    buffer.append("1,"); //count
     buffer.append(Integer.toString(length)); buffer.append(',');
     buffer.append(Integer.toString(queue)); buffer.append(',');
-    buffer.append(Long.toString(min)); buffer.append(',');
-    buffer.append(Long.toString(max)); buffer.append(',');
+    buffer.append(Long.toString(new Double(Math.floor(min)).longValue())); buffer.append(',');
+    buffer.append(Long.toString(new Double(Math.ceil(max)).longValue())); buffer.append(',');
     buffer.append(source); buffer.append(',');
     //TODO: parse this in the formatting processor or get it as a program argument
     buffer.append("AUTO");
@@ -97,17 +83,15 @@ public class Segment implements Comparable<Segment>{
     public static void put(ByteBuffer buffer, Segment s) {
       buffer.putLong(s.id);
       buffer.putLong(s.next_id);
-      buffer.putLong(s.min);
-      buffer.putLong(s.max);
-      buffer.putInt(s.duration);
+      buffer.putDouble(s.min);
+      buffer.putDouble(s.max);
       buffer.putInt(s.length);
       buffer.putInt(s.queue);
-      buffer.putInt(s.count);
     }
     
     public static Segment get(ByteBuffer buffer) {
-      return new Segment(buffer.getLong(), buffer.getLong(), buffer.getLong(), buffer.getLong(), 
-          buffer.getInt(), buffer.getInt(), buffer.getInt(), buffer.getInt());
+      return new Segment(buffer.getLong(), buffer.getLong(), buffer.getDouble(), buffer.getDouble(), 
+          buffer.getInt(), buffer.getInt());
     }
 
     public Serializer<Segment> serializer() {

--- a/src/main/java/io/opentraffic/reporter/TimeQuantisedTile.java
+++ b/src/main/java/io/opentraffic/reporter/TimeQuantisedTile.java
@@ -25,7 +25,9 @@ public class TimeQuantisedTile implements Comparable<TimeQuantisedTile>{
   
   public static List<TimeQuantisedTile> getTiles(Segment segment, int quantization) {
     List<TimeQuantisedTile> tiles = new ArrayList<TimeQuantisedTile>();
-    for(long i = segment.min/quantization; i <= segment.max/quantization; i++) {
+    long min = new Double(segment.min).longValue();
+    long max = new Double(segment.max).longValue();
+    for(long i = min/quantization; i <= max/quantization; i++) {
       long start = i * quantization;
       tiles.add(new TimeQuantisedTile(start, segment.getTileId()));
     }


### PR DESCRIPTION
this python program mimics everything that is happening between the java kafka workers and the python reporter service but doesn't require kafka or running and http server. instead its meant to be run on the command line to import a chunk of data is if it were the java kafka worker PUTing files to s3.

i'm still in the testing phases but all of the parts are there and they seemed to work in isolation so after working out a few kinks of chaining them together we should be able to give this a shot for a simpler way to load historical dumps of data.