### PR TITLE
allow kafka and simple reporters to do level 2 and to set travel mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,23 +139,77 @@ You'll also notice that there are tons of options to the kafka stream program so
 ```
 usage: kafka-reporter
  -b,--bootstrap <arg>         Bootstrap servers config
- -d,--duration <arg>          How long to run the program in seconds, defaults to (essentially) forever.
- -f,--formatter <arg>         The formatter configuration separated args for constructing a custom formatter. Separated value and json are currently supported. To construct a seprated value formatter where the raw messages look like:
-                              2017-01-31 16:00:00|uuid_abcdef|x|x|x|accuracy|x|x|x|lat|lon|x|x|x
+ -d,--duration <arg>          How long to run the program in seconds,
+                              defaults to (essentially) forever.
+ -f,--formatter <arg>         The formatter configuration separated args
+                              for constructing a custom formatter.
+                              Separated value and json are currently
+                              supported.
+                              To construct a seprated value formatter
+                              where the raw messages look like:
+                              2017-01-31
+                              16:00:00|uuid_abcdef|x|x|x|accuracy|x|x|x|la
+                              t|lon|x|x|x
                               Specify a value of:
-                              --formatter ",sv,\|,1,9,10,0,5,yyyy-MM-dd HH:mm:ss"
-                              To construct a json formatter where the raw messages look like:
-                              {"timestamp":1495037969,"id":"uuid_abcdef","accuracy":51.305,"latitude":3.465725,"longitude":-76.5135033}
+                              --formatter ",sv,\|,1,9,10,0,5,yyyy-MM-dd
+                              HH:mm:ss"
+                              To construct a json formatter where the raw
+                              messages look like:
+                              {"timestamp":1495037969,"id":"uuid_abcdef","
+                              accuracy":51.305,"latitude":3.465725,"longit
+                              ude":-76.5135033}
                               Specify a value of:
-                              --formatter ",json,id,latitude,longitude,timestamp,accuracy"
-                              Note that the time format string is optional, ie when your time value is already in epoch seconds.
- -i,--flush-interval <arg>    The interval, in seconds, at which tiles are flushed to storage. Do not set this parameter lower than the quantisation. Doing so could result in tiles with very few segment pairs.
- -o,--output-location <arg>   A location to put the output histograms. This can either be an http://location to POST to or /a/directory to write files to. If its of the form https://*.amazonaws.com its assumed to be an s3 bucket and you'll need to have the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY properly set.
- -p,--privacy <arg>           The minimum number of observations of a given segment pair required before including this pair in the histogram.
- -q,--quantisation <arg>      The granularity, in seconds, at which to combine observations into as single tile. Setting this to 3600 will result in tiles where all segment pairs occuring within a given hour will be in the same tile. Do not set this parameter higher than the flush interval parameter. Doing so could result in tiles with very few segment pairs
- -s,--source <arg>            The name used in the tiles as a means of identifying the source of the data.
- -t,--topics <arg>            A comma separated list of topics listed in the order they are operated on in the kafka stream.The first topic is the raw unformatted input messages. The second is the formatted messages. The third is segments. The fourth is the anonymised segments.
- -u,--reporter-url <arg>      The url to send batched/windowed portions of a given keys points to.
+                              --formatter
+                              ",json,id,latitude,longitude,timestamp,accur
+                              acy"
+                              Note that the time format string is
+                              optional, ie when your time value is already
+                              in epoch seconds.
+ -i,--flush-interval <arg>    The interval, in seconds, at which tiles are
+                              flushed to storage. Do not set this
+                              parameter lower than the quantisation. Doing
+                              so could result in tiles with very few
+                              segment pairs.
+ -m,--mode <arg>              The mode of travel the input data used.
+                              Defaults to auto(mobile)
+ -o,--output-location <arg>   A location to put the output histograms.
+                              This can either be an http://location to
+                              POST to or /a/directory to write files to.
+                              If its of the form https://*.amazonaws.com
+                              its assumed to be an s3 bucket and you'll
+                              need to have the environment variables
+                              AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+                              properly set.
+ -p,--privacy <arg>           The minimum number of observations of a
+                              given segment pair required before including
+                              this pair in the histogram.
+ -q,--quantisation <arg>      The granularity, in seconds, at which to
+                              combine observations into as single tile.
+                              Setting this to 3600 will result in tiles
+                              where all segment pairs occuring within a
+                              given hour will be in the same tile. Do not
+                              set this parameter higher than the flush
+                              interval parameter. Doing so could result in
+                              tiles with very few segment pairs
+ -r,--reports <arg>           The levels of osmlr segments we will report
+                              on as the first segment in the segment pair.
+                              Defaults to 0,1. Any combination of 0,1,2 is
+                              allowed
+ -s,--source <arg>            The name used in the tiles as a means of
+                              identifying the source of the data.
+ -t,--topics <arg>            A comma separated list of topics listed in
+                              the order they are operated on in the kafka
+                              stream.The first topic is the raw
+                              unformatted input messages. The second is
+                              the formatted messages. The third is
+                              segments. The fourth is the anonymised
+                              segments.
+ -u,--reporter-url <arg>      The url to send batched/windowed portions of
+                              a given keys points to.
+ -x,--transitions <arg>       The levels of osmlr segments we will report
+                              on as the second segment in the segment
+                              pair. Defaults to 0,1. Any combination of
+                              0,1,2 is allowed
 ```
 
 #### Maintainance
@@ -246,11 +300,15 @@ usage: simple_reporter.py [-h] --src-bucket SRC_BUCKET --src-prefix SRC_PREFIX
                           [--src-key-regex SRC_KEY_REGEX]
                           [--src-valuer SRC_VALUER]
                           [--src-time-pattern SRC_TIME_PATTERN] --match-config
-                          MATCH_CONFIG [--quantisation QUANTISATION]
+                          MATCH_CONFIG [--mode MODE]
+                          [--report-levels REPORT_LEVELS]
+                          [--transition-levels TRANSITION_LEVELS]
+                          [--quantisation QUANTISATION]
                           [--inactivity INACTIVITY] [--privacy PRIVACY]
                           [--source-id SOURCE_ID] [--dest-bucket DEST_BUCKET]
                           [--concurrency CONCURRENCY] [--bbox BBOX]
                           [--trace-dir TRACE_DIR] [--match-dir MATCH_DIR]
+                          [--cleanup CLEANUP]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -268,6 +326,12 @@ optional arguments:
                         string
   --match-config MATCH_CONFIG
                         A file containing the config for the map matcher
+  --mode MODE           The mode of transport used in generating the input
+                        trace data
+  --report-levels REPORT_LEVELS
+                        Comma seprated list of levels to report on
+  --transition-levels TRANSITION_LEVELS
+                        Comma separated list of levels to allow transitions on
   --quantisation QUANTISATION
                         How large are the buckets to make tiles for. They
                         should always be an hour (3600 seconds)
@@ -293,6 +357,7 @@ optional arguments:
   --match-dir MATCH_DIR
                         To bypass trace matching supply the directory with the
                         already matched segments
+  --cleanup CLEANUP     Should temporary files be removed or not
 ```
 
 Note that the program requires access to the map matching python module and a match config. The module is currently only available on linux and so the use of the program would depend on having access to a linux machine or docker.

--- a/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/AnonymisingProcessor.java
@@ -61,6 +61,7 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
   private final int privacy;      //number of observations required to make it into a tile
   private final long interval;    //how frequently to dump tiles to external location
   private final int quantisation; //what is the resolution for time buckets
+  private final String mode;      //what type of transport mode to report on
   private final String source;    //how we'll identify ourselves to the external datastore
   private final String output;    //where should the output go
   private final boolean bucket;   //if the output should go to an s3 bucket
@@ -77,6 +78,7 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
     quantisation = Integer.parseInt(cmd.getOptionValue("quantisation"));
     if(quantisation < 60)
       throw new RuntimeException("Need quantisation parameter of 60 or more");
+    mode = cmd.getOptionValue("mode", "auto").toUpperCase();
     output = cmd.getOptionValue("output-location").replaceAll("/+$", "");
     source = cmd.getOptionValue("source");
     
@@ -177,7 +179,7 @@ public class AnonymisingProcessor implements ProcessorSupplier<String, Segment> 
         StringBuffer buffer = new StringBuffer(segments.size() * 64);
         buffer.append(Segment.columnLayout());
         for(Segment segment : segments)
-          segment.appendToStringBuffer(buffer, source);
+          segment.appendToStringBuffer(buffer, mode, source);
         
         //figure out some naming
         String tile_name = Long.toString(tile.time_range_start) + '_' +

--- a/src/main/java/io/opentraffic/reporter/Batch.java
+++ b/src/main/java/io/opentraffic/reporter/Batch.java
@@ -55,7 +55,7 @@ public class Batch {
     //make a post body: uuid json + uuid + trace json + number of points * (single point json) + end of json array and object 
     StringBuilder sb = new StringBuilder();
     sb.ensureCapacity(9 + key.length() + 11 + points.size() * (18 + 18 + 13 + 22 + 1) + 2);
-    sb.append("{\"uuid\":\""); sb.append(key); sb.append("\",{\"match_options\":{\"mode\":\"");
+    sb.append("{\"uuid\":\""); sb.append(key); sb.append("\",\"match_options\":{\"mode\":\"");
     sb.append(mode); sb.append("\"},\"trace\":[");
     for(Point p : points) {
       Point.Serder.put_json(p, sb);

--- a/src/main/java/io/opentraffic/reporter/Batch.java
+++ b/src/main/java/io/opentraffic/reporter/Batch.java
@@ -46,7 +46,7 @@ public class Batch {
     points.add(p);
   }
   
-  public JsonNode report(String key, String url, int min_dist, int min_size, long min_elapsed) {
+  public JsonNode report(String key, String url, String mode, int min_dist, int min_size, long min_elapsed) {
     //if it doesnt meet the requirements then bail
     if(max_separation < min_dist || points.size() < min_size ||
         points.get(points.size() - 1).time - points.get(0).time < min_elapsed)
@@ -55,7 +55,8 @@ public class Batch {
     //make a post body: uuid json + uuid + trace json + number of points * (single point json) + end of json array and object 
     StringBuilder sb = new StringBuilder();
     sb.ensureCapacity(9 + key.length() + 11 + points.size() * (18 + 18 + 13 + 22 + 1) + 2);
-    sb.append("{\"uuid\":\""); sb.append(key); sb.append("\",\"trace\":[");
+    sb.append("{\"uuid\":\""); sb.append(key); sb.append("\",{\"match_options\":{\"mode\":");
+    sb.append(mode); sb.append("},\"trace\":[");
     for(Point p : points) {
       Point.Serder.put_json(p, sb);
       sb.append(',');

--- a/src/main/java/io/opentraffic/reporter/Batch.java
+++ b/src/main/java/io/opentraffic/reporter/Batch.java
@@ -55,8 +55,8 @@ public class Batch {
     //make a post body: uuid json + uuid + trace json + number of points * (single point json) + end of json array and object 
     StringBuilder sb = new StringBuilder();
     sb.ensureCapacity(9 + key.length() + 11 + points.size() * (18 + 18 + 13 + 22 + 1) + 2);
-    sb.append("{\"uuid\":\""); sb.append(key); sb.append("\",{\"match_options\":{\"mode\":");
-    sb.append(mode); sb.append("},\"trace\":[");
+    sb.append("{\"uuid\":\""); sb.append(key); sb.append("\",{\"match_options\":{\"mode\":\"");
+    sb.append(mode); sb.append("\"},\"trace\":[");
     for(Point p : points) {
       Point.Serder.put_json(p, sb);
       sb.append(',');

--- a/src/main/java/io/opentraffic/reporter/Batch.java
+++ b/src/main/java/io/opentraffic/reporter/Batch.java
@@ -46,7 +46,7 @@ public class Batch {
     points.add(p);
   }
   
-  public JsonNode report(String key, String url, String mode, int min_dist, int min_size, long min_elapsed) {
+  public JsonNode report(String key, String url, String mode, String report_on, String transition_on, int min_dist, int min_size, long min_elapsed) {
     //if it doesnt meet the requirements then bail
     if(max_separation < min_dist || points.size() < min_size ||
         points.get(points.size() - 1).time - points.get(0).time < min_elapsed)
@@ -56,7 +56,8 @@ public class Batch {
     StringBuilder sb = new StringBuilder();
     sb.ensureCapacity(9 + key.length() + 11 + points.size() * (18 + 18 + 13 + 22 + 1) + 2);
     sb.append("{\"uuid\":\""); sb.append(key); sb.append("\",\"match_options\":{\"mode\":\"");
-    sb.append(mode); sb.append("\"},\"trace\":[");
+    sb.append(mode); sb.append("\",\"report_levels\":["); sb.append(report_on);
+    sb.append("],\"transition_levels\":["); sb.append(transition_on); sb.append("]},\"trace\":[");
     for(Point p : points) {
       Point.Serder.put_json(p, sb);
       sb.append(',');

--- a/src/main/java/io/opentraffic/reporter/BatchingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/BatchingProcessor.java
@@ -28,10 +28,12 @@ public class BatchingProcessor implements ProcessorSupplier<String, Point> {
   private final int REPORT_DIST = 500;   //meters
   private final long SESSION_GAP = 60000;//milliseconds
   private final String url;
+  private final String mode;
 
   public BatchingProcessor(CommandLine cmd) {
     logger.debug("Instantiating batching processor");
     url = cmd.getOptionValue("reporter-url");
+    mode = cmd.getOptionValue("mode", "auto");
   }
   
   @Override
@@ -59,7 +61,8 @@ public class BatchingProcessor implements ProcessorSupplier<String, Point> {
         else {
           batch.update(point);
           int length = batch.points.size();
-          int reported = forward(batch.report(key, url, REPORT_DIST, REPORT_COUNT, REPORT_TIME));
+          //TODO: send options about what levels to report on and transitions to allow
+          int reported = forward(batch.report(key, url, mode, REPORT_DIST, REPORT_COUNT, REPORT_TIME));
           if(reported > 0)
             logger.debug("Reported on " + reported + " segment pairs");
           if(batch.points.size() != length)
@@ -90,7 +93,7 @@ public class BatchingProcessor implements ProcessorSupplier<String, Point> {
             logger.debug("Evicting " + kv.key + " as it was stale");
             store.delete(kv.key);
             //report what we can if we can
-            int reported = forward(kv.value.report(kv.key, url, 0, 2, 0));
+            int reported = forward(kv.value.report(kv.key, url, mode, 0, 2, 0));
             if(reported > 0)
               logger.debug("Reported on " + reported + " segment pairs during eviction");
           }

--- a/src/main/java/io/opentraffic/reporter/BatchingProcessor.java
+++ b/src/main/java/io/opentraffic/reporter/BatchingProcessor.java
@@ -29,11 +29,15 @@ public class BatchingProcessor implements ProcessorSupplier<String, Point> {
   private final long SESSION_GAP = 60000;//milliseconds
   private final String url;
   private final String mode;
+  private final String report_on;
+  private final String transition_on;
 
   public BatchingProcessor(CommandLine cmd) {
     logger.debug("Instantiating batching processor");
     url = cmd.getOptionValue("reporter-url");
     mode = cmd.getOptionValue("mode", "auto");
+    report_on = cmd.getOptionValue("reports", "0,1");
+    transition_on = cmd.getOptionValue("transitions", "0,1");
   }
   
   @Override
@@ -62,7 +66,7 @@ public class BatchingProcessor implements ProcessorSupplier<String, Point> {
           batch.update(point);
           int length = batch.points.size();
           //TODO: send options about what levels to report on and transitions to allow
-          int reported = forward(batch.report(key, url, mode, REPORT_DIST, REPORT_COUNT, REPORT_TIME));
+          int reported = forward(batch.report(key, url, mode, report_on, transition_on, REPORT_DIST, REPORT_COUNT, REPORT_TIME));
           if(reported > 0)
             logger.debug("Reported on " + reported + " segment pairs");
           if(batch.points.size() != length)
@@ -93,7 +97,7 @@ public class BatchingProcessor implements ProcessorSupplier<String, Point> {
             logger.debug("Evicting " + kv.key + " as it was stale");
             store.delete(kv.key);
             //report what we can if we can
-            int reported = forward(kv.value.report(kv.key, url, mode, 0, 2, 0));
+            int reported = forward(kv.value.report(kv.key, url, mode, report_on, transition_on, 0, 2, 0));
             if(reported > 0)
               logger.debug("Reported on " + reported + " segment pairs during eviction");
           }

--- a/src/main/java/io/opentraffic/reporter/Reporter.java
+++ b/src/main/java/io/opentraffic/reporter/Reporter.java
@@ -68,6 +68,14 @@ public class Reporter {
     Option mode = new Option("m", "mode", true, "The mode of travel the input data used. Defaults to auto(mobile)");
     mode.setRequired(false);
     
+    Option reports = new Option("r", "reports", true, "The levels of osmlr segments we will report on as the first segment in the segment pair."
+        + " Defaults to 0,1. Any combination of 0,1,2 is allowed");
+    reports.setRequired(false);
+    
+    Option transitions = new Option("x", "transitions", true, "The levels of osmlr segments we will report on as the second segment in the segment pair."
+        + " Defaults to 0,1. Any combination of 0,1,2 is allowed");
+    transitions.setRequired(false);
+    
     Option privacy = new Option("p", "privacy", true, "The minimum number of observations of a given segment pair "
         + "required before including this pair in the histogram.");
     privacy.setRequired(true);
@@ -103,6 +111,8 @@ public class Reporter {
     options.addOption(formatter);
     options.addOption(url);
     options.addOption(mode);
+    options.addOption(reports);
+    options.addOption(transitions);
     options.addOption(privacy);
     options.addOption(quantisation);
     options.addOption(interval);

--- a/src/main/java/io/opentraffic/reporter/Reporter.java
+++ b/src/main/java/io/opentraffic/reporter/Reporter.java
@@ -65,6 +65,9 @@ public class Reporter {
     Option url = new Option("u", "reporter-url", true, "The url to send batched/windowed portions of a given keys points to.");
     url.setRequired(true);
     
+    Option mode = new Option("m", "mode", true, "The mode of travel the input data used. Defaults to auto(mobile)");
+    mode.setRequired(false);
+    
     Option privacy = new Option("p", "privacy", true, "The minimum number of observations of a given segment pair "
         + "required before including this pair in the histogram.");
     privacy.setRequired(true);
@@ -99,6 +102,7 @@ public class Reporter {
     options.addOption(topics);
     options.addOption(formatter);
     options.addOption(url);
+    options.addOption(mode);
     options.addOption(privacy);
     options.addOption(quantisation);
     options.addOption(interval);

--- a/src/main/java/io/opentraffic/reporter/Segment.java
+++ b/src/main/java/io/opentraffic/reporter/Segment.java
@@ -56,7 +56,7 @@ public class Segment implements Comparable<Segment>{
     return "segment_id,next_segment_id,duration,count,length,queue_length,minimum_timestamp,maximum_timestamp,source,vehicle_type";
   }
   
-  public void appendToStringBuffer(StringBuffer buffer, String source) {
+  public void appendToStringBuffer(StringBuffer buffer, String mode, String source) {
     buffer.append('\n');
     buffer.append(Long.toString(id)); buffer.append(',');
     if(next_id != INVALID_SEGMENT_ID)
@@ -70,8 +70,7 @@ public class Segment implements Comparable<Segment>{
     buffer.append(Long.toString(new Double(Math.floor(min)).longValue())); buffer.append(',');
     buffer.append(Long.toString(new Double(Math.ceil(max)).longValue())); buffer.append(',');
     buffer.append(source); buffer.append(',');
-    //TODO: parse this in the formatting processor or get it as a program argument
-    buffer.append("AUTO");
+    buffer.append(mode);
   }
   
   public static class Serder implements Serde<Segment> {

--- a/src/main/java/io/opentraffic/reporter/Segment.java
+++ b/src/main/java/io/opentraffic/reporter/Segment.java
@@ -42,7 +42,7 @@ public class Segment implements Comparable<Segment>{
   @Override
   public String toString() {
     StringBuffer b = new StringBuffer(64);
-    appendToStringBuffer(b, "");
+    appendToStringBuffer(b, "", "");
     return b.toString();
   }
   


### PR DESCRIPTION
there should be changes in the readme to match the updated options to the programs. i think this is a fatal flaw of the readme. everytime we update a programs options, the readme must be manually changed. can we not copy paste the `--help` output of programs into the readmes? i think we can expect people to be able to just run the program with the help option to see the output.